### PR TITLE
fix: 更新文件名时因时区问题更新时间错误

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -170,7 +170,7 @@ func UpdateLFSObjFileName(oid, newFileName, operator string) error {
 	updateData := map[string]interface{}{
 		"file_name":   newFileName,
 		"operator":    operator,
-		"update_time": time.Now(),
+		"update_time": time.Now().Add(8 * time.Hour),
 	}
 
 	if err := tx.Model(&LfsObj{}).


### PR DESCRIPTION
更新文件名时因时区问题更新时间错误，需要加8h